### PR TITLE
Fix find free command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -256,6 +256,12 @@ Format `findtask KEYWORD`
 * Only the task name is searched.
 * Partial words will be matched e.g. `report` will match `reports`
 
+### Finding a free person : `findfree`
+
+Finds the person(s) who has no current task.
+
+Format `findfree`
+
 ### Filtering employees by efficiency: `filter_efficiency`
 
 Filters employees with efficiency less than or equals to a given threshold.
@@ -355,6 +361,7 @@ Action     | Format, Examples
 **Filter Department**  | `filter KEYWORD [MORE_KEYWORDS]`<br> e.g., `filter Finance`
 **Filter Efficiency**   | `filter_efficiency THRESHOLD`<br> e.g., `filter_efficiency 40`
 **Find Task**   | `findtask KEYWORD`<br> e.g., `findtask Project`
+**Find Free Person** | `findfree`
 **Comment** | `comment 1 c/ Good at database management.`
 **List**   | `list`
 **Clear**  | `clear`

--- a/src/main/java/seedu/address/model/person/PersonHasNoTaskPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonHasNoTaskPredicate.java
@@ -13,7 +13,7 @@ public class PersonHasNoTaskPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return person.isBusy();
+        return !person.isBusy();
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/FindFreePersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindFreePersonCommandTest.java
@@ -25,7 +25,7 @@ public class FindFreePersonCommandTest {
 
     @Test
     public void execute_multiplePersonsFoundWithNoTasks_multiplePersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 4);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         FindFreePersonCommand command = new FindFreePersonCommand();
         expectedModel.updateFilteredPersonList(new PersonHasNoTaskPredicate());
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/model/person/PersonHasNoTaskPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonHasNoTaskPredicateTest.java
@@ -31,7 +31,7 @@ class PersonHasNoTaskPredicateTest {
     public void test_personIsNotBusy_returnsFalse() {
         // Person is not busy
         PersonHasNoTaskPredicate predicate = new PersonHasNoTaskPredicate();
-        assertFalse(predicate.test(new PersonBuilder().build()));
+        assertTrue(predicate.test(new PersonBuilder().build()));
     }
 
     @Test


### PR DESCRIPTION
Original predicated was checking for `isBusy()` instead of `!isBusy()`.